### PR TITLE
Fixed Error Detecting No Changes To Tag

### DIFF
--- a/vro/git.go
+++ b/vro/git.go
@@ -65,6 +65,11 @@ func IsChangelogUpToDate(wd, chgLogFile string) (bool, error) {
 }
 
 func lastUpdateWasAutoChangelog(wd string) bool {
-	lasLog := git.LastLog(wd)
-	return strings.Contains(lasLog, "An automated update of CHANGELOG.md")
+	lastLog := git.Log(wd, "HEAD")
+	return strings.Contains(lastLog, "An automated update of CHANGELOG.md")
+}
+
+func IsChangeLogCommit(wd, commit string) bool {
+	log := git.Log(wd, commit)
+	return strings.Contains(log, "An automated update of CHANGELOG.md")
 }

--- a/vro/main.go
+++ b/vro/main.go
@@ -251,6 +251,11 @@ func main() {
 			return
 		}
 
+		// if it has no tag, then also verify its not an changelog update commit
+		if IsChangeLogCommit(wd, commit) {
+			log.Logf(stdout.ChangelogCommit, commit)
+			return
+		}
 		// Step 6: Build pipeline parameters to trigger the tag-and-release
 		// workflow
 		pp, errY1 := circleci.GetPipelineParameters(branch, publishReleaseTagWorkflow)

--- a/vro/message.go
+++ b/vro/message.go
@@ -39,30 +39,32 @@ var stderr = struct {
 }
 
 var stdout = struct {
-	Cs             string
-	CurrentVersion string
-	CurrentVer     string
-	FoundChgInFile string
-	GitStatus      string
-	Match          string
-	NoCommitsToTag string
-	NextVersion    string
-	NoTags         string
-	ReleaseTag     string
-	StartWorkflow  string
-	Wd             string
+	ChangelogCommit string
+	Cs              string
+	CurrentVersion  string
+	CurrentVer      string
+	FoundChgInFile  string
+	GitStatus       string
+	Match           string
+	NoCommitsToTag  string
+	NextVersion     string
+	NoTags          string
+	ReleaseTag      string
+	StartWorkflow   string
+	Wd              string
 }{
-	Cs:             "cs: %s",
-	CurrentVersion: "%v, %v",
-	CurrentVer:     "current version %v",
-	FoundChgInFile: "running %s produced changes in the %s",
-	GitStatus:      "Git status: %v",
-	Match:          "entry for %v in the changelog was found, we assume this means the changelog is up-to-date",
-	NextVersion:    "next version %v",
-	NoCommitsToTag: "no commits to tag",
-	ReleaseTag:     "releasing %v",
-	StartWorkflow:  "starting %v workflow",
-	Wd:             "wd: %s",
+	ChangelogCommit: "commit %v is a changelog commit",
+	Cs:              "cs: %s",
+	CurrentVersion:  "%v, %v",
+	CurrentVer:      "current version %v",
+	FoundChgInFile:  "running %s produced changes in the %s",
+	GitStatus:       "Git status: %v",
+	Match:           "entry for %v in the changelog was found, we assume this means the changelog is up-to-date",
+	NextVersion:     "next version %v",
+	NoCommitsToTag:  "no commits to tag",
+	ReleaseTag:      "releasing %v",
+	StartWorkflow:   "starting %v workflow",
+	Wd:              "wd: %s",
 }
 
 var um = map[string]string{

--- a/vro/pkg/git/command.go
+++ b/vro/pkg/git/command.go
@@ -155,6 +155,22 @@ func LastLog(wd string) string {
 	return string(so)
 }
 
+// Log Return a commit log.
+func Log(wd, refId string) string {
+	so, se, _, _ := cli.RunCommand(
+		wd,
+		cmdGit,
+		[]string{"log", refId, "-1"},
+	)
+
+	if se != nil {
+		log.Errf(stderr.CommitLog, se.Error())
+		return ""
+	}
+
+	return string(so)
+}
+
 // Push Pushes changes to an origin.
 // git push origin <branch_name>
 func Push(wd, origin, branch string) error {

--- a/vro/pkg/git/command_test.go
+++ b/vro/pkg/git/command_test.go
@@ -61,19 +61,20 @@ func TestHasSemverTag(t *testing.T) {
 	}
 }
 
-func TestLastLog(t *testing.T) {
+func TestLog(t *testing.T) {
 	tests := []struct {
 		name   string
 		bundle string
+		refID  string
 		want   string
 	}{
-		{"success", "repo-03", "test1234"},
+		{"success", "repo-03", "HEAD", "test1234"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			repo := help.SetupARepository(tt.bundle, tmpDir, fixtureDir, ps)
 
-			if got := LastLog(repo); !strings.Contains(got, tt.want) {
+			if got := Log(repo, tt.refID); !strings.Contains(got, tt.want) {
 				t.Errorf("LastLog() = %v, want %v", got, tt.want)
 			}
 		})

--- a/vro/pkg/git/message.go
+++ b/vro/pkg/git/message.go
@@ -1,6 +1,7 @@
 package git
 
 var stderr = struct {
+	CommitLog                string
 	CouldNotAddOrigin        string
 	CouldNotCheckoutBranch   string
 	CouldNotCommit           string
@@ -14,6 +15,7 @@ var stderr = struct {
 	GitDescribeContains      string
 	LastLog                  string
 }{
+	CommitLog:                "could not get commit log: %s",
 	CouldNotAddOrigin:        "problem adding the origin %s: %s, %s",
 	CouldNotCheckoutBranch:   "could not checkout branch: %s; %v",
 	CouldNotGetRemoteUrl:     "problem getting the remote push URL: %s, %s",


### PR DESCRIPTION
When there were no changes to tag, and tag-and-release was executed. This changes that behavior to fail gracefully.