### PR TITLE
Added Publish Multiple Images With A Single Job

### DIFF
--- a/src/jobs/publish-docker-hub.yml
+++ b/src/jobs/publish-docker-hub.yml
@@ -37,11 +37,15 @@ parameters:
         type: string
     image_tag:
         default: ""
-        description: A tag to stamp the image in Docker Hub.
+        description: Obsolete, use tags parameter instead. This parameter will be removed in the next major release. A single tag to stamp the image in Docker Hub.
         type: string
     repository:
         description: |2
           Docker Hub image repository for example "kohirens/version-release".
+        type: string
+    tags:
+        default: ""
+        description: Tags to stamp the image and push to Docker Hub. Space delimited.
         type: string
     target:
         default: ""
@@ -58,6 +62,7 @@ environment:
     DOCKER_BUILDKIT: << parameters.docker_buildkit >>
     DOCKER_FILE: << parameters.dockerfile >>
     IMG_TAG: << parameters.image_tag >>
+    TAGS: << parameters.tags >>
     REPOSITORY: << parameters.repository >>
     TARGET: << parameters.target >>
 

--- a/src/tests/bin/docker
+++ b/src/tests/bin/docker
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+set -e
+
+if [ "${1}" = "build" ]; then
+    tag_name="${4}"
+    build_file="${6}"
+    build_target="${8}"
+    build_args="${10}"
+    build_context="${11}"
+    e_tag_name="example/com:abc123"
+    e_build_file="path/to/Dockerfile"
+    e_build_target="test-target"
+    e_build_args="ARG1"
+    e_build_context="."
+
+    echo "checking docker build command input"
+    if [ "${tag_name}" != "${e_tag_name}" ]; then
+        echo "expected tag ${e_tag_name}, got ${tag_name}"
+        exit 1
+    fi
+
+    if [ "${build_file}" != "${e_build_file}" ]; then
+        echo "expected tag ${e_build_file}, got ${build_file}"
+        exit 1
+    fi
+
+    if [ "${build_target}" != "${e_build_target}" ]; then
+        echo "expected tag ${e_build_target}, got ${build_target}"
+        exit 1
+    fi
+
+    if [ "${build_args}" != "${e_build_args}" ]; then
+        echo "expected build args ${e_build_args}, got ${build_args}"
+        exit 1
+    fi
+
+    if [ "${build_context}" != "${e_build_context}" ]; then
+        echo "expected build args ${e_build_context}, got ${build_context}"
+        exit 1
+    fi
+fi
+
+
+if [ "${1}" = "tag" ]; then
+    image="${2}"
+    tag="${3}"
+    e_image="example/com:abc123"
+
+    echo "checking docker tag command input"
+    if [ "${image}" != "${e_image}" ]; then
+        echo "expected image ${e_image}, got ${image}"
+        exit 1
+    fi
+
+    if [ "${tag}" != "example/com:latest" ] && [ "${tag}" != "example/com:1.0.0" ]; then
+        echo "expected tags latest or 1.0.0, got ${tag}"
+        exit 1
+    fi
+fi
+
+if [ "${1}" = "push" ]; then
+    image="${2}"
+    echo "checking docker push command input"
+
+    if [ "${image}" != "example/com:latest" ] && [ "${image}" != "example/com:1.0.0" ]; then
+        echo "expected tags latest or 1.0.0, got ${image}"
+        exit 1
+    fi
+fi
+
+if [ "${1}" = "rmi" ]; then
+    image="${2}"
+    echo "checking docker rmi command input"
+
+    if [ "${image}" != "example/com:latest" ] && [ "${image}" != "example/com:1.0.0" ] && [ "${image}" != "example/com:abc123" ]; then
+        echo "expected tags latest or 1.0.0, abc123, got ${image}"
+        exit 1
+    fi
+fi

--- a/src/tests/publish-docker-hub.bats
+++ b/src/tests/publish-docker-hub.bats
@@ -1,0 +1,54 @@
+InstallPseudoDocker() {
+    if [ ! -f "/home/circleci/bin/docker" ]; then
+        wd=$(pwd)
+        cp src/tests/bin/docker /home/circleci/bin
+    fi
+    chmod +x /home/circleci/bin/docker
+    export PATH="/home/circleci/bin:${PATH}"
+}
+
+# Runs prior to every test
+setup() {
+    # Install required software
+    InstallPseudoDocker
+}
+
+@test '1: publish multiple docker images' {
+    # setup
+    export BUILD_CONTEXT="."
+    export TAGS="latest 1.0.0"
+    export REPOSITORY="example/com"
+    export CIRCLE_SHA1="abc123"
+    export DH_PASS="fakePass"
+    export DH_USER="fakeUser"
+    export DOCKER_FILE="path/to/Dockerfile"
+    export TARGET="test-target"
+    export BUILD_ARGS="--build-arg ARG1"
+
+    # test
+    source ./src/scripts/publish-docker-hub.sh
+
+    # assert
+    result="${?}"
+    [ "${result}" == "0" ]
+}
+
+@test '2: publish a docker image' {
+    # setup
+    export BUILD_CONTEXT="."
+    export IMG_TAG="1.0.0"
+    export REPOSITORY="example/com"
+    export CIRCLE_SHA1="abc123"
+    export DH_PASS="fakePass"
+    export DH_USER="fakeUser"
+    export DOCKER_FILE="path/to/Dockerfile"
+    export TARGET="test-target"
+    export BUILD_ARGS="--build-arg ARG1"
+
+    # test
+    source ./src/scripts/publish-docker-hub.sh
+
+    # assert
+    result="${?}"
+    [ "${result}" == "0" ]
+}


### PR DESCRIPTION
Allow multiple tags to be entered (space delimited) when publishing an image to Docker Hub. This should reduce the need to duplicate the job when needing to tag a single image with multiple tags.