### PR TITLE
Changed How Environment Variable Are Sourced

### DIFF
--- a/src/scripts/publish-docker-hub.sh
+++ b/src/scripts/publish-docker-hub.sh
@@ -41,7 +41,8 @@ if [ -z "${REPOSITORY}" ]; then
 fi
 
 if [ -n "${ENV_FILE}" ]; then
-    ./"${ENV_FILE}"
+    # shellcheck disable=SC1090
+    source "${ENV_FILE}"
 fi
 
 export DH_IMAGE="${REPOSITORY}:${CIRCLE_SHA1}"


### PR DESCRIPTION
When passing environment variables to the publish-docker-hub job, source them an more portable way.