### PR TITLE
Embed Auto Version Release Scripts in the Container Image

### DIFF
--- a/.docker/vr/Dockerfile
+++ b/.docker/vr/Dockerfile
@@ -100,10 +100,11 @@ RUN wget https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VER}/
 
 RUN rm /usr/local/bin/git-chglog
 
-USER ${USER_NAME}
-
 # Add build artifacts
-COPY --from=build --chown=${USER_NAME}:${USER_GROUP} "/home/${USER_NAME}/bin/vro" "/home/${USER_NAME}/bin/vro"
+COPY --from=build "/home/${USER_NAME}/bin/vro" "/usr/local/bin/vro"
+COPY --chmod=+x ./src/scripts/ /usr/local/bin/
+
+USER ${USER_NAME}
 
 ENV PATH="${PATH}:/home/${USER_NAME}/bin"
 


### PR DESCRIPTION
Embedding these scripts will allow them to be run from the container so that CircleCI Orb and GitHub Actions can use them and prevent them from being deployed to multiple locations. 

The scripts will be owned by root as a best security practice to prevent their replacement at runtime.