### PR TITLE
Change Release Image

### DIFF
--- a/.docker/vr/Dockerfile
+++ b/.docker/vr/Dockerfile
@@ -109,7 +109,11 @@ RUN ls -la /usr/local/bin \
  && chmod +x /usr/local/bin/*.sh \
  && ls -la /usr/local/bin
 
-ENV PATH="${PATH}:/home/${USER_NAME}/bin"
+USER ${USER_NAME}
 
 ENTRYPOINT [ "vro" ]
 # docker build --rm -t kohirens/version-release:dev -f .docker/vr/Dockerfile .
+CMD [ "--help" ]
+# Flatten
+FROM scratch
+COPY --link / /

--- a/.docker/vr/Dockerfile
+++ b/.docker/vr/Dockerfile
@@ -101,10 +101,13 @@ RUN wget https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VER}/
 RUN rm /usr/local/bin/git-chglog
 
 # Add build artifacts
-COPY --from=build "/home/${USER_NAME}/bin/vro" "/usr/local/bin/vro"
-COPY --chmod=+x ./src/scripts/ /usr/local/bin/
+COPY --link --from=build "/home/${USER_NAME}/bin/vro" "/usr/local/bin/vro"
+COPY --link --chmod=755 ./src/scripts/ /usr/local/bin/
 
-USER ${USER_NAME}
+# DEBUG
+RUN ls -la /usr/local/bin \
+ && chmod +x /usr/local/bin/*.sh \
+ && ls -la /usr/local/bin
 
 ENV PATH="${PATH}:/home/${USER_NAME}/bin"
 

--- a/src/scripts/publish-docker-hub.sh
+++ b/src/scripts/publish-docker-hub.sh
@@ -66,7 +66,17 @@ $build_cmd
 
 for tag in ${TAGS}; do
     stamp="${REPOSITORY}:${tag}"
-    docker tag "${DH_IMAGE}" "${stamp}"
+    # BEGIN flatten_image_layers
+    # 1. Run a container.
+    docker run --entrypoint sh --rm -dt --name vro "${DH_IMAGE}"
+    sleep 7
+    # 2. Export the container to an tar.
+    docker export vro > flat_image.tar
+    # 3. Stop the container.
+    docker stop vro
+    # 4. Import the image with desired tag.
+    docker import -c 'ENTRYPOINT [ "vro" ]' -c 'CMD [ "-help" ]' flat_image.tar "${stamp}"
+    # End flatten_image_layers
 
     printf "\nPushing %s\n" "${stamp}"
     docker push "${stamp}"


### PR DESCRIPTION
## Changed

* Optimize the Release Image:
    * Removed the `/home/circleci/bin` directory from the PATH environment
      variable.
    * Updated the `publish-docker-hub` job to flatten the image. This cut
      about 70MB off the Auto Version Release image in local testing.

## Fixed

* Missing Execute Permissions On Scripts - The Auto Version Release scripts added to the `/usr/local/bin` directory where missing the execute permissions. Even with DOCKER_BUILDKIT=1 set in the environment. Changed the permissions to 755 and also add the execute bit with a RUN command in the Dockerfile should fix this.