### PR TITLE
Fixed Invalid Type Used In Selector Workflow

### DIFF
--- a/.github/workflows/selector.yml
+++ b/.github/workflows/selector.yml
@@ -37,7 +37,7 @@ on:
                 description: |2
                   Prefix git tags with a "v" before the semantic version number.
                 required: false
-                type: bool
+                type: boolean
             github_api_url:
                 default: "https://api.github.com"
                 description: Github API URL.


### PR DESCRIPTION
The wrong type keyword was used for enabling the tag prefix options. This has been fixed to use the correct `boolean` type.