### PR TITLE
Fixed GitHub Actions Selecting a Workflow

### DIFF
--- a/templates/selector.yml
+++ b/templates/selector.yml
@@ -37,7 +37,7 @@ on:
                 description: |2
                   Prefix git tags with a "v" before the semantic version number.
                 required: false
-                type: bool
+                type: boolean
             github_api_url:
                 default: "https://api.github.com"
                 description: Github API URL.


### PR DESCRIPTION
There workflow selector template had a type set to "bool" instead of "boolean".