### PR TITLE
chg: Remove GitHub Actions Required Parameter

### DIFF
--- a/templates/selector.yml
+++ b/templates/selector.yml
@@ -46,7 +46,7 @@ on:
             github_server:
                 default: "github.com"
                 description: GitHub server domain name.
-                required: true
+                required: false
                 type: string
         secrets:
             github_write_token:


### PR DESCRIPTION
The GitHub server parameter was changed to use a default.