### PR TITLE
Removed: GitHub Action Requirement

### DIFF
--- a/.github/workflows/selector.yml
+++ b/.github/workflows/selector.yml
@@ -82,8 +82,6 @@ jobs:
                   github_api_url: ${{ inputs.github_api_url }}
                   github_server: ${{ inputs.github_server }}
     publish-changelog:
-        permissions:
-            contents: write
         if: ${{ needs.select-a-workflow.outputs.workflow == 'publish-changelog' }}
         runs-on: ubuntu-latest
         name: Publish changelog workflow


### PR DESCRIPTION
Removed the write permission requirement for the GitHub Action publish-changelog job.